### PR TITLE
Change git project link from hg.prod.canaltp.fr to github.com in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Dependence:
 Requirements
 -------------
 
-1. [MediaManager (Component)](http://hg.prod.canaltp.fr/ctp/MediaManager.git/summary)
+1. [MediaManager (Component)](https://github.com/CanalTP/MediaManagerComponent)
 2. [NavitiaComponent](http://hg.prod.canaltp.fr/ctp/NavitiaComponent.git/summary)
 
 Installation


### PR DESCRIPTION
Maybe you must create a https://github.com/CanalTP/NavitiaComponent too ?
Without that the entire MediaManagerBundle github project is unusable.